### PR TITLE
Remove unused SSH passphrase in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,5 @@ jobs:
         username: ${{ secrets.SSH_USERNAME }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         port: ${{ secrets.SSH_PORT }}
-        passphrase: ${{ secrets.SSH_PASSPHRASE }}
         source: nginx/*
         target: ${{ secrets.TARGET_PATH }}


### PR DESCRIPTION
This pull request removes the unused SSH passphrase in the deploy workflow. The passphrase was previously included in the workflow configuration but is no longer needed. This change simplifies the workflow and improves security by removing the unnecessary passphrase.