### PR TITLE
Enable SSL and revert deploy settings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: deploy
 
 on:
   push:
-    branches:
-      - master
+    # branches:
+    #   - master
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: deploy
 
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - master
 
 jobs:
   build:

--- a/nginx/default
+++ b/nginx/default
@@ -24,8 +24,8 @@ server {
 
 	# SSL configuration
 	#
-	# listen 443 ssl default_server;
-	# listen [::]:443 ssl default_server;
+	listen 443 ssl default_server;
+	listen [::]:443 ssl default_server;
 	#
 	# Note: You should disable gzip for SSL traffic.
 	# See: https://bugs.debian.org/773332
@@ -44,6 +44,15 @@ server {
 	index index.html index.htm index.nginx-debian.html;
 
 	server_name _;
+
+	ssl_protocols TLSv1.2 TLSv1.3;
+	ssl_ciphers HIGH:!MEDIUM:!LOW:!aNULL:!NULL:!SHA;
+	ssl_prefer_server_ciphers on;
+	ssl_session_cache shared:SSL:10m;
+	ssl_session_tickets off;
+
+	ssl_certificate     /etc/letsencrypt/live/nagiyu.com/fullchain.pem;
+	ssl_certificate_key /etc/letsencrypt/live/nagiyu.com/privkey.pem;
 
 	location / {
 		# First attempt to serve request as file, then


### PR DESCRIPTION
This pull request includes two commits. The first commit enables SSL by updating the server configuration to listen on port 443 and adding SSL certificates. The second commit reverts the deploy settings to a previous state.