### PR TITLE
Update nginx configuration to allow access from localhost

### DIFF
--- a/nginx/default
+++ b/nginx/default
@@ -121,7 +121,7 @@ server {
 	listen 80;
 	server_name dev-secret.nagiyu.com;
 
-	location /manager {
+	location ^~ /manager {
 		proxy_pass http://localhost:9005;
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
This pull request updates the nginx configuration to allow access from localhost in the location block. This change ensures that requests to the /manager endpoint are properly proxied to http://localhost:9005.