### PR TITLE
Update nginx configuration to allow access from localhost and route requests to the correct subproject

### DIFF
--- a/nginx/default
+++ b/nginx/default
@@ -119,6 +119,34 @@ server {
 
 server {
 	listen 80;
+	server_name secret.nagiyu.com;
+
+	location / {
+		deny all;
+
+		proxy_pass http://localhost:9002;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
+	}
+}
+
+server {
+	listen 80;
+	server_name secret-manager.nagiyu.com;
+
+	location / {
+		proxy_pass http://localhost:9003;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
+	}
+}
+
+server {
+	listen 80;
 	server_name dev-secret.nagiyu.com;
 
 	location / {


### PR DESCRIPTION
This pull request updates the nginx configuration to allow access from localhost and route requests to the correct subproject. It adds new server blocks for `secret.nagiyu.com` and `secret-manager.nagiyu.com`, with appropriate proxy settings. This ensures that requests to these domains are correctly forwarded to the corresponding subprojects running on `localhost:9002` and `localhost:9003` respectively.